### PR TITLE
removed unused variable in favour of more ugly code for codacy

### DIFF
--- a/pygyro/utilities/grid_plotter.py
+++ b/pygyro/utilities/grid_plotter.py
@@ -562,7 +562,7 @@ class SlicePlotterNd(object):
                 self.buttons[1].set_active(True)
             else:
                 self.prepare_data_reception()
-            for i, x in enumerate(self.completedRanks):
+            for i in range(len(self.completedRanks)):
                 self.completedRanks[i] = (i == self.drawRank)
 
         if (not self.mpi_playing):


### PR DESCRIPTION
replaced `enumerate` loop by `range(len())` in order not to have unused variable name (Codacy doesn't like this)