### PR TITLE
Correct angle bug

### DIFF
--- a/pygyro/advection/accelerated_advection_steps.py
+++ b/pygyro/advection/accelerated_advection_steps.py
@@ -278,6 +278,8 @@ def poloidal_advection_step_impl(f: 'float[:,:]', dt: 'float', v: 'float', rPts:
                     endPts_k2_r[i, j] = rMax
 
                 diff = abs(endPts_k2_q[i, j]-endPts_k1_q[i, j])
+                if diff > pi:
+                    diff = 2*pi-diff
                 if (diff > norm):
                     norm = diff
                 diff = abs(endPts_k2_r[i, j]-endPts_k1_r[i, j])

--- a/pygyro/advection/accelerated_advection_steps.py
+++ b/pygyro/advection/accelerated_advection_steps.py
@@ -279,7 +279,7 @@ def poloidal_advection_step_impl(f: 'float[:,:]', dt: 'float', v: 'float', rPts:
 
                 diff = abs(endPts_k2_q[i, j]-endPts_k1_q[i, j])
                 if diff > pi:
-                    diff = 2*pi-diff
+                    diff = 2*pi - diff
                 if (diff > norm):
                     norm = diff
                 diff = abs(endPts_k2_r[i, j]-endPts_k1_r[i, j])


### PR DESCRIPTION
The difference between 2 angles needs to take into account the behaviour of values close to theta=0. This was not done correctly leading to infinite loops on implicit tests.

Eg:
```
q1 = 15 * pi / 16
q2 = pi/16
diff = 14 pi / 16 # should equal -pi/8
```